### PR TITLE
Product document type

### DIFF
--- a/fullstack/src/app/firebase/config.ts
+++ b/fullstack/src/app/firebase/config.ts
@@ -2,8 +2,6 @@ import { FirebaseApp, FirebaseOptions, initializeApp } from 'firebase/app';
 import { Auth, getAuth } from 'firebase/auth';
 import { DocumentData, Firestore, getFirestore, QueryDocumentSnapshot } from 'firebase/firestore';
 
-type DocSnapshotArray = QueryDocumentSnapshot<DocumentData, DocumentData>[];
-
 const appOptions: FirebaseOptions = {
     apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
     appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
@@ -19,4 +17,3 @@ const db: Firestore = getFirestore(app);
 const auth: Auth = getAuth(app);
 
 export { app, db, auth };
-export type { DocSnapshotArray };

--- a/fullstack/src/app/firebase/config.ts
+++ b/fullstack/src/app/firebase/config.ts
@@ -1,6 +1,8 @@
 import { FirebaseApp, FirebaseOptions, initializeApp } from 'firebase/app';
 import { Auth, getAuth } from 'firebase/auth';
-import { Firestore, getFirestore } from 'firebase/firestore';
+import { DocumentData, Firestore, getFirestore, QueryDocumentSnapshot } from 'firebase/firestore';
+
+type DocSnapshotArray = QueryDocumentSnapshot<DocumentData, DocumentData>[];
 
 const appOptions: FirebaseOptions = {
     apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -17,3 +19,4 @@ const db: Firestore = getFirestore(app);
 const auth: Auth = getAuth(app);
 
 export { app, db, auth };
+export type { DocSnapshotArray };

--- a/fullstack/src/app/firebase/products.ts
+++ b/fullstack/src/app/firebase/products.ts
@@ -1,7 +1,24 @@
 import { db } from '@/app/firebase/config'
-import { collection, DocumentData, getDocs, QueryDocumentSnapshot,query,limit } from 'firebase/firestore'
+import { collection, DocumentData, getDocs, QueryDocumentSnapshot, query, limit } from 'firebase/firestore'
 
-const collectionNames = ["wands","spellBooks","staffs","scrolls","magicItems","ingredients","cursedItems","creatures"];
+const collectionNames = ["wands", "spellBooks", "staffs", "scrolls", "magicItems", "ingredients", "cursedItems", "creatures"];
+
+interface Product {
+    id: string,
+    imageSrc?: string,
+    name?: string,
+    price?: number
+};
+
+async function getProducts(): Promise<Product[]> {
+    const docs = await getProductDocuments();
+    return docs.map(doc => ({
+        id: doc.id,
+        imageSrc: doc.data().imageSrc,
+        name: doc.data().name,
+        price: doc.data().price
+    }));
+}
 
 async function getProductDocuments(): Promise<QueryDocumentSnapshot<DocumentData>[]> {
     try {
@@ -9,9 +26,9 @@ async function getProductDocuments(): Promise<QueryDocumentSnapshot<DocumentData
 
         for (const collectionName of collectionNames) {
             const collectionRef = collection(db, collectionName);
-            const limitedDocs = query(collectionRef,limit(3));
+            const limitedDocs = query(collectionRef, limit(3));
             const querySnapshot = await getDocs(limitedDocs);
-            allDocs = [...allDocs, ...querySnapshot.docs]; 
+            allDocs = [...allDocs, ...querySnapshot.docs];
         }
 
         return allDocs;
@@ -21,4 +38,5 @@ async function getProductDocuments(): Promise<QueryDocumentSnapshot<DocumentData
     }
 }
 
-export {getProductDocuments};
+export { getProductDocuments, getProducts };
+export type { Product };

--- a/fullstack/src/app/firebase/products.ts
+++ b/fullstack/src/app/firebase/products.ts
@@ -5,9 +5,9 @@ const collectionNames = ["wands", "spellBooks", "staffs", "scrolls", "magicItems
 
 interface Product {
     id: string,
-    imageSrc?: string,
-    name?: string,
-    price?: number
+    imageSrc: string,
+    name: string,
+    price: number
 };
 
 async function getProducts(): Promise<Product[]> {

--- a/fullstack/src/app/search/page.tsx
+++ b/fullstack/src/app/search/page.tsx
@@ -1,14 +1,16 @@
 'use client';
 
-import { SiteHeader } from "@/components/SiteHeader/site-header";
 import { useEffect, useState } from "react";
-import { getProductDocuments } from "../firebase/products";
-import { DocumentData, QueryDocumentSnapshot } from "firebase/firestore";
+
+import { SiteHeader } from "@/components/SiteHeader/site-header";
 import { ProductCard } from "@/components/ProductCard/product-card";
+
+import { DocSnapshotArray } from "../firebase/config";
+import { getProductDocuments } from "../firebase/products";
 
 export default function Search() {
 
-    const [products, setProducts] = useState<QueryDocumentSnapshot<DocumentData, DocumentData>[] | undefined>(undefined);
+    const [products, setProducts] = useState<DocSnapshotArray | undefined>(undefined);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(false);
 

--- a/fullstack/src/app/search/page.tsx
+++ b/fullstack/src/app/search/page.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 import { SiteHeader } from "@/components/SiteHeader/site-header";
 import { ProductCard } from "@/components/ProductCard/product-card";
 
-import { getProductDocuments, getProducts, Product } from "../firebase/products";
+import { getProducts, Product } from "../firebase/products";
 
 export default function Search() {
 

--- a/fullstack/src/app/search/page.tsx
+++ b/fullstack/src/app/search/page.tsx
@@ -5,17 +5,16 @@ import { useEffect, useState } from "react";
 import { SiteHeader } from "@/components/SiteHeader/site-header";
 import { ProductCard } from "@/components/ProductCard/product-card";
 
-import { DocSnapshotArray } from "../firebase/config";
-import { getProductDocuments } from "../firebase/products";
+import { getProductDocuments, getProducts, Product } from "../firebase/products";
 
 export default function Search() {
 
-    const [products, setProducts] = useState<DocSnapshotArray | undefined>(undefined);
+    const [products, setProducts] = useState<Product[] | undefined>(undefined);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(false);
 
     useEffect(() => {
-        getProductDocuments().then(products => {
+        getProducts().then(products => {
             setProducts(products)
         }).catch(_ => {
             setError(true);
@@ -34,7 +33,7 @@ export default function Search() {
                     <div>
                         <p>Products</p>
                         <div className="flex flex-wrap gap-4">
-                            {products.map(product => { return <ProductCard key={product.id} name={""} price={99} /> })}
+                            {products.map(product => { return <ProductCard key={product.id} name={product.name} price={product.price} imageSrc={product.imageSrc} /> })}
                         </div>
                     </div>
                 }

--- a/fullstack/src/components/ProductCard/product-card.tsx
+++ b/fullstack/src/components/ProductCard/product-card.tsx
@@ -2,14 +2,13 @@ import {
     Card,
     CardContent,
     CardFooter,
-    CardHeader,
 } from "@/components/ui/card"
 
 
 interface ProductCardProps {
     key?: string,
-    name: string,
-    price: number,
+    name?: string,
+    price?: number,
     imageSrc?: string
 }
 


### PR DESCRIPTION
* Added `Product` type
* Added `getProducts()` function
* Used new type and function in search page
* Removed old document snapshot array type 

I've added a type for our Firebase product documents to prevent us from having to write them out each time. It also adds autocomplete for the document properties.